### PR TITLE
Smarter result counts

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,10 +51,12 @@ async function getDirectedLinks(subject, pageNumber, pageSize) {
     } LIMIT ${pageSize}  OFFSET ${offset}
   `);
 
-  const queryResultCount = await query(`SELECT (COUNT( DISTINCT (?o)) as ?count)
+  const queryResultCount = await query(`SELECT (COUNT( (?p)) as ?count)
    WHERE {
      GRAPH <http://mu.semte.ch/application> {
-      ${sparqlEscapeUri(subject)} ?p ?o.
+       SELECT DISTINCT ?p ?o WHERE {
+         ${sparqlEscapeUri(subject)} ?p ?o.
+       }
      }
    }
    `);
@@ -80,10 +82,12 @@ async function getInverseLinks(subject, pageNumber, pageSize) {
     } LIMIT ${pageSize}  OFFSET ${offset}
   `);
 
-  const inverseQueryResultCount = await query(`SELECT (COUNT( DISTINCT (?s)) as ?count)
+  const inverseQueryResultCount = await query(`SELECT (COUNT( (?p)) as ?count)
    WHERE {
      GRAPH <http://mu.semte.ch/application> {
-       ?s ?p ${sparqlEscapeUri(subject)}.
+       SELECT DISTINCT ?p ?o WHERE {
+         ?s ?p ${sparqlEscapeUri(subject)}.
+       }
      }
    }
    `);

--- a/app.js
+++ b/app.js
@@ -82,10 +82,10 @@ async function getInverseLinks(subject, pageNumber, pageSize) {
     } LIMIT ${pageSize}  OFFSET ${offset}
   `);
 
-  const inverseQueryResultCount = await query(`SELECT (COUNT( (?p)) as ?count)
+  const inverseQueryResultCount = await query(`SELECT (COUNT( (?s)) as ?count)
    WHERE {
      GRAPH <http://mu.semte.ch/application> {
-       SELECT DISTINCT ?p ?o WHERE {
+       SELECT DISTINCT ?s ?o WHERE {
          ?s ?p ${sparqlEscapeUri(subject)}.
        }
      }


### PR DESCRIPTION
This implementation comes from discussions with @wschella and @cecemel

The previous solution counted the amount of distinct objects which may
not represent the amount of triples starting with that subject.

An initial assumption would be that the following query would yield the
desired result-set.

    SELECT (COUNT (DISTINCT *) AS ?count)
    WHERE {
      <http://example.com/42> ?p ?o.
    }

That does not seem to be the case in the currently used sparql
implementation.

This implementation is an elegant solution to the problem taking the
form of a subselect query.

    SELECT (COUNT *) AS ?count)
    WHERE {
      SELECT DISTINCT ?p ?o
      WHERE {
        <http://example.com/42> ?p ?o.
      }
    }

The inner query constructs a result set with one match for each `?p ?o`
tuple.  Counting these (already distinct) rows thus counts all triples
which which have that subject.

The inverse implementation is analogous.