### PR TITLE
adds a describe route to the service

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,12 @@
 // see https://github.com/mu-semtech/mu-javascript-template for more info
 
 import { app, query, errorHandler, sparqlEscapeUri } from 'mu';
+import { Readable } from 'stream';
+import { rdfSerializer } from 'rdf-serialize';
+import { DataFactory } from 'n3';
+import stringifyStream from 'stream-to-string';
+
+const { namedNode, literal, quad } = DataFactory;
 
 app.get('/', async function (req, res) {
   const subject = req.query["subject"];
@@ -36,9 +42,97 @@ app.get('/inverse', async function (req, res) {
   const pageNumber = req.query["pageNumber"] || 0;
   const pageSize = req.query["pageSize"] || 500;
 
-  const response = await getInverseLinks(subject, pageNumber, pageSize)
+  const response = await getInverseLinks(subject, pageNumber, pageSize);
   res.send(response);
 });
+
+app.get('/describe', async function (req, res) {
+  const uri = req.query.uri;
+  const acceptHeader = req.get('Accept') || '';
+
+  if (!uri) {
+    return res.status(400).json({ error: 'URI parameter is required' });
+  }
+
+  res.set('Vary', 'Accept');
+
+  const supportedFormats = [
+    'application/n-triples',
+    'text/turtle',
+    'application/rdf+xml',
+    'application/ld+json'
+  ];
+
+  let contentType = null;
+  for (const format of supportedFormats) {
+    if (acceptHeader.includes(format)) {
+      contentType = format;
+      break;
+    }
+  }
+
+  if (!contentType) {
+    return res.status(406).json({
+      error: 'Not Acceptable. Supported formats: application/n-triples, text/turtle, application/rdf+xml, application/ld+json'
+    });
+  }
+
+  try {
+    const describeQuery = `DESCRIBE ${sparqlEscapeUri(uri)}`;
+    const queryResult = await query(describeQuery);
+
+    const quads = sparqlResultToQuads(queryResult);
+    const quadStream = Readable.from(quads);
+
+    const textStream = rdfSerializer.serialize(quadStream, { contentType });
+    const serializedData = await stringifyStream(textStream);
+
+    res.set('Content-Type', contentType);
+    res.send(serializedData);
+  } catch (error) {
+    console.error('Error in describe route:', error);
+    res.status(500).json({ error: 'Failed to describe resource' });
+  }
+});
+
+function sparqlResultToQuads(queryResult) {
+  const quads = [];
+
+  if (queryResult.results && queryResult.results.bindings) {
+    for (const binding of queryResult.results.bindings) {
+      if (binding.s && binding.p && binding.o) {
+        const subject = termToRDFJS(binding.s);
+        const predicate = termToRDFJS(binding.p);
+        const object = termToRDFJS(binding.o);
+
+        quads.push(quad(subject, predicate, object));
+      }
+    }
+  }
+
+  return quads;
+}
+
+
+function termToRDFJS(term) {
+  switch (term.type) {
+    case 'uri':
+      return namedNode(term.value);
+    case 'literal':
+    case 'typed-literal':
+      if (term.datatype) {
+        return literal(term.value, namedNode(term.datatype));
+      } else if (term.lang || term['xml:lang']) {
+        return literal(term.value, term.lang || term['xml:lang']);
+      } else {
+        return literal(term.value);
+      }
+    case 'bnode':
+      return DataFactory.blankNode(term.value);
+    default:
+      throw new Error(`Unknown term type: ${term.type}`);
+  }
+}
 
 async function getDirectedLinks(subject, pageNumber, pageSize) {
   const offset = pageSize * pageNumber;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1554 @@
+{
+  "name": "mu-uri-info-service",
+  "version": "0.2.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mu-uri-info-service",
+      "version": "0.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "jsonld": "^9.0.0",
+        "jsonld-streaming-serializer": "^4.0.0",
+        "n3": "^1.26.0",
+        "rdf-parse": "^4.0.0",
+        "rdf-serialize": "^4.0.1",
+        "rdf-store-stream": "^3.0.0",
+        "stream-to-string": "^1.2.1"
+      }
+    },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.2.tgz",
+      "integrity": "sha512-qUt0QNJjvg4s1zk+AuLM6s/zcsQ8MvGn7+1f0vPuxvpCYa08YtTryuDInngbEyW5fNGGYe2znKt61RMGd5HnXg==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.5.0.tgz",
+      "integrity": "sha512-KbLuhbTcfAQHJeLo3CDDdffCZdfA1qDu15XIdW+7P03UpUp9xMw4p1G0kYtoXwj9KzWguY704TUtpJVBO1GOnw==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-4.5.0.tgz",
+      "integrity": "sha512-THNdQsJ58HtkyeW9ghVyLrYEQfSPNfmVAJTDSqOxIujjCdimPbzS2LBXoDdw13GuxWWOATssbm1LwXDlX0xMIQ==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-4.5.0.tgz",
+      "integrity": "sha512-rhPBWOWe0tGDgwXbRgURwiGcbw1KY58oMByT7MVi5SLMpiK1Tjjb6KoMz5SOkZWsD1z6JY65J/VLxKFSj37ogQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-time": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-4.5.0.tgz",
+      "integrity": "sha512-M5UQ+/IqXFNXLu9qSFNeeph/vaP349HQozqZzOY+HTO4TNWSIcB/XO6HgE3SC7r4G+KV+s9WbHwQO/8PxshBPQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-time": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-4.5.0.tgz",
+      "integrity": "sha512-43PrAVCdHLcbJtPqZOVB9/4Zm5EDwIZrzUJhFPx7y30lzda1LmchL5aPrn5OPyrP3/AxK6U0Y9ISDZOBguOAEw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "htmlparser2": "^10.0.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-4.5.0.tgz",
+      "integrity": "sha512-wxoXLS0nxV4ZqJEsx+zdZLjkRxZPFo+bXt+0fVEuDdBwL5WaJ6WPEL3fqbiH3QuaTu08k9klnsg2L1ncCeHhGg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "microdata-rdf-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-4.5.0.tgz",
+      "integrity": "sha512-o39tqHXAvKHnsa82Zm5FIbDRj+CSN46Nxj19TBSpCIsRlv5wJ9NpD6yxd7nGr1ovS5/5Ky7vDSdLcJ0MnJaNSQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-4.5.0.tgz",
+      "integrity": "sha512-eobWYbV4w7o/NK+6GMVkcaoGEQbTq2RmDDN63J1I/U0sTSQX0qvtLr0L4buOzGliIUttBbpsYfOc5YtJX6PP0g==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.5.2",
+        "relative-to-absolute-iri": "^1.0.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-4.5.0.tgz",
+      "integrity": "sha512-QuYhMRNH7oc2RjpDCUWNoZiEkwgOGgQvT+GnCZz2pd2kHuTcH3iBo5FvDTLornSVO0RVchcpWGItN9zA2dCNoQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-4.5.0.tgz",
+      "integrity": "sha512-rERwWLr+fiFWuzWJe5Zoh0JvlaZn9DkvFGRl/5DntnDuwI91/U/p/atXBKfz/abpPAUs4hRGj5gkqmfdZg/bBQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "n3": "^1.26.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-4.5.0.tgz",
+      "integrity": "sha512-KDmXZ7w++eMO1HXaKwbkx6o5wKTtSMTCdhMGb/ewHinw4XVwesAy9nu/C5CAhi8LpCjdAxa7kf5POejBXUWd3Q==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "rdfxml-streaming-parser": "^2.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-4.5.0.tgz",
+      "integrity": "sha512-YFYn9ml/eCfZhBTYeaYJ0Qk6HerBi0H4acZYppcMKdh/GPJklzW9LOLlEfEzYstrqwPIKZzqgoBg5yvVgbmXpA==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "readable-stream": "^4.5.2",
+        "shaclc-parse": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-4.5.0.tgz",
+      "integrity": "sha512-1uQuq3xsokT0wWf9O6d+SyuNEvGX+bgSSGBCQF9YDjc2RygiZATUdThDmh4VDUYJzUCxHb3YM1XyJ+U2Si6xpA==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-4.5.0.tgz",
+      "integrity": "sha512-mHGiQ6roZaDNvhzlaSSXMPoLZpQypHY/+QLc8veR9lMWfsyo/BYBbhtVlVRU9r8rRe4EfSidAwxtfYhyiSzxuQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "jsonld-streaming-serializer": "^3.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-jsonld/node_modules/jsonld-streaming-serializer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-3.0.1.tgz",
+      "integrity": "sha512-lw5Z785Km53DRZ0ngyEamC3ojGdjFRDKvUt3b7lW5e8sqmTc7GHZxFBBw7IIqbb0Wc2WNksoXewmF13FC9bPNg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "jsonld-context-parser": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-n3": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-4.5.0.tgz",
+      "integrity": "sha512-VdhSUe9Ph5CdxuEILyKRtjeNGO5RcwpID/5zIItXJfiZeaeyBepIOAyFNzbk+M0tfMCtFOZKmSGFqGATZY2Dew==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^4.5.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-shaclc": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-4.5.0.tgz",
+      "integrity": "sha512-XC1YhgwXq9tEF9wPNZZOMtPo6oaQUlZnj3tPSRVHpi84bUveRcIJsaNmLUeudqMKTW6cwarAnDrwqtonaBJVsA==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^4.5.0",
+        "arrayify-stream": "^2.0.1",
+        "readable-stream": "^4.5.2",
+        "shaclc-write": "^1.4.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-http": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-4.5.0.tgz",
+      "integrity": "sha512-wWyPNNOl6shDbtibdBl/pa9OIcoEMemNIo/J4tUViXxYXZ8i1h4FZ6PqaLtAls6O+pV71mR4SKJzKEUuiZiXPg==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "is-stream": "^2.0.1",
+        "readable-from-web": "^1.0.0",
+        "readable-stream-node-to-web": "^1.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-init": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-4.5.0.tgz",
+      "integrity": "sha512-9TYFLjirHDt7HPXj3eQW9KX3x5T3mZ1G/EKadL1gQxo0FAqs3y8TdicepCLhk3HY/egidlyv9WQYAPvJ+WAmAg==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-4.5.0.tgz",
+      "integrity": "sha512-TnTS9F2GSbibuCd0Rep20C9WXU0KH0iWl2S2xycefMFrZK7noA8LeT/AHNshQlMPKejKxWME+jNsvcXgC++8zw==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^4.5.0",
+        "@comunica/actor-abstract-parse": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-4.5.0.tgz",
+      "integrity": "sha512-yKsPuCIOLF5TXqoXXo+utZehG2diTCBnNleXrOI8Utr4Qu5rAU4oQ5+FC0UByMu5hr+g/TGm2A+IHSVzFRCUfw==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-serialize": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-4.5.0.tgz",
+      "integrity": "sha512-4hBw+34Q1SoW1iBgw2UaAli+UcHTdxTNvNFKlJizsN1G20YNJYi/xS9cE36mSZO+pntYxQRRN2cp8Ou622pkig==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/config-query-sparql": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-4.4.0.tgz",
+      "integrity": "sha512-ZVK6eqpYLNa3MRLOWjRaudgfSdraJH/oZIkc5S2doJI2ZmnHROqQUtjPs13kwkI3hGZ6MVBtLm55oz+tKj2lKA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/context-entries": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-4.5.0.tgz",
+      "integrity": "sha512-mgeSYFBcpMKLq34COpy129LVHigGUgA1uEI66WXmk3mdmlAKRQNe9D/W2Q924w0FZZmIOpeLMo+s358tFsodow==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.5.0.tgz",
+      "integrity": "sha512-Z4uLxugl+Ls8oAwD0dAIQg+i1rkiXbpiFLhgv5h6nksnz9q6Nv14xItm6baivxAJ9p8XVHCOwPxW46YJBtWIoQ==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-union": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-4.5.0.tgz",
+      "integrity": "sha512-aCoO3CiANssR8PEjad2aNuCcfhKdUFZWplTWq77cVUMVc4nsUWNleeEvN6kfOx51qdT8lFpH3b8X+S7bT8CABg==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-number": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-4.5.0.tgz",
+      "integrity": "sha512-fChc4gh+gtwPOS0F5eNeDuU4Kyb2fAuppN28d1/5s+OUr5v+1Wya7yZ1zbPHYxDMWZEpJBR06eX6djcI0gKlkQ==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-race": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-4.5.0.tgz",
+      "integrity": "sha512-eAWjQolFMOxKoKuUMmcQzxwf/ZL9ooT0/OUWv1vbVfHIQb/eqDs/h8wDqwXMgEiK5dIF9ZQYaRL2vEaLq+U3Ew==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-4.5.0.tgz",
+      "integrity": "sha512-HND+om4L0VW3VcQrLHHE4+7Nsg7soC98i7g7UqqzDkJ4fix2FnJs0i9WH4RP+oLcx+bPhBSl5mG1m44A6sV19g==",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/types/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/@digitalbazaar/http-client": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.2.0.tgz",
+      "integrity": "sha512-OGju/GYp0V72qlZ/Pd4jGEwqBwT/Za/tw+Z3AC7lgMheGqsbhTZrtc5iLz9z59G/Q53QyE2fnjHV8N9wjBpiWA==",
+      "dependencies": {
+        "ky": "^1.7.5",
+        "undici": "^6.21.2"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@jeswr/prefixcc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jeswr/prefixcc/-/prefixcc-1.2.1.tgz",
+      "integrity": "sha512-kBBXbqsaeh3Irp416h/RbelqJgIOp6X/OJJlYmLyr/9qlBYKTKSCuEv5/xjZ0Yf8Yec+QFRYBaOQ2JkMBSH7KA==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/@jeswr/stream-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jeswr/stream-to-string/-/stream-to-string-2.0.0.tgz",
+      "integrity": "sha512-VmoW6xYRjVzdMr2njBObVSlUc5KCJT+gyuuH+tea9ZLE59XhgfLNc8ufN5Md38STxCyAJUDUVcCBfaOo11BfuA==",
+      "dependencies": {
+        "event-emitter-promisify": "^1.1.0"
+      }
+    },
+    "node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.12"
+      }
+    },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
+      "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.22.tgz",
+      "integrity": "sha512-/FFhJpfCLAPwAcN3mFycNUa77ddnr8jTgF5VmSNetaemWB2cIlfCA9t0YTM3JAT0wOcv8D4tjPo7pkDhK3EJIg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sparqljs": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.12.tgz",
+      "integrity": "sha512-zg/sdKKtYI0845wKPSuSgunyU1o/+7tRzMw85lHsf4p/0UbA6+65MXAyEtv1nkaqSqrq/bXm7+bqXas+Xo5dpQ==",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/arrayify-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-2.0.1.tgz",
+      "integrity": "sha512-z8fB6PtmnewQpFB53piS2d1KlUi3BPMICH2h7leCOUXpQcwvZ4GbHHSpdKoUrgLMR6b4Qan/uDe1St3Ao3yIHg=="
+    },
+    "node_modules/asynciterator": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.10.0.tgz",
+      "integrity": "sha512-eDOBoUf2m+4ht0ETVn2SCfuBIZZ6UWyyQbP++LRPKoK7PmrCQq37pJ6vRvyef4o1Pn+CwWnzMlkXxGdh/krVIw==",
+      "dependencies": {
+        "tiny-set-immediate": "^1.0.2"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/event-emitter-promisify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/event-emitter-promisify/-/event-emitter-promisify-1.1.0.tgz",
+      "integrity": "sha512-uyHG8gjwYGDlKoo0Txtx/u1HI1ubj0FK0rVqI4O0s1EymQm4iAEMbrS5B+XFlSaS8SZ3xzoKX+YHRZk8Nk/bXg=="
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/immutable": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
+      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA=="
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonld": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsonld-context-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.0.0.tgz",
+      "integrity": "sha512-Kg6TVtBUdIm057ht/8WNhM9BROt+BeYaDGXbzrKaa3xA99csee+CsD8IMCTizRgzoO8PIzvzcxxCoRvpq1xNQw==",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/jsonld-streaming-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz",
+      "integrity": "sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^3.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
+    },
+    "node_modules/jsonld-streaming-serializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-4.0.0.tgz",
+      "integrity": "sha512-YUg5Er7CSWB6+ZiHreBUoBILEttowto/fT654W5a+6iIiAI65Jz023Wtsi/XUCLUkItDWYe6ckYUbCV1aSQbtA==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0",
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "jsonld-context-parser": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.0.tgz",
+      "integrity": "sha512-Rczb6FMM6JT0lvrOlP5WUOCB7s9XKxzwgErzhKlKde1bEV90FXplV1o87fpt4PU/asJFiqjYJxAJyzJhcrxOsQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/n3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz",
+      "integrity": "sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
+    },
+    "node_modules/rdf-canonize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-4.0.0.tgz",
+      "integrity": "sha512-lNVuUKPVAdX9lJYYrJFhdQHFulYjk95BYvuNsE+eUs/M93sdsovH/Ga8bTAxagmpsoQ4LzMPa2YqeHX8ysltOA==",
+      "dependencies": {
+        "@comunica/actor-http-fetch": "^4.0.1",
+        "@comunica/actor-http-proxy": "^4.0.1",
+        "@comunica/actor-rdf-parse-html": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^4.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^4.0.1",
+        "@comunica/actor-rdf-parse-n3": "^4.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^4.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^4.0.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^4.0.1",
+        "@comunica/bus-http": "^4.0.1",
+        "@comunica/bus-init": "^4.0.1",
+        "@comunica/bus-rdf-parse": "^4.0.1",
+        "@comunica/bus-rdf-parse-html": "^4.0.1",
+        "@comunica/config-query-sparql": "^4.0.1",
+        "@comunica/context-entries": "^4.0.1",
+        "@comunica/core": "^4.0.1",
+        "@comunica/mediator-combine-pipeline": "^4.0.1",
+        "@comunica/mediator-combine-union": "^4.0.1",
+        "@comunica/mediator-number": "^4.0.1",
+        "@comunica/mediator-race": "^4.0.1",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2",
+        "readable-stream": "^4.5.2",
+        "stream-to-string": "^1.2.1"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-serialize": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-serialize/-/rdf-serialize-4.0.1.tgz",
+      "integrity": "sha512-iPeyp8WWdyuZvDBRgIaTJCeRSalI3+qOaHIrvrXIAAfRpI4iMgpPpJJgDKVYd1PiedxGtpdjh3tA0VlxAhzqNw==",
+      "dependencies": {
+        "@comunica/actor-rdf-serialize-jsonld": "^4.0.1",
+        "@comunica/actor-rdf-serialize-n3": "^4.0.1",
+        "@comunica/actor-rdf-serialize-shaclc": "^4.0.1",
+        "@comunica/bus-init": "^4.0.1",
+        "@comunica/bus-rdf-serialize": "^4.0.1",
+        "@comunica/config-query-sparql": "^4.0.1",
+        "@comunica/core": "^4.0.1",
+        "@comunica/mediator-combine-pipeline": "^4.0.1",
+        "@comunica/mediator-combine-union": "^4.0.1",
+        "@comunica/mediator-race": "^4.0.1",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.5.2",
+        "stream-to-string": "^1.1.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-store-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-3.0.0.tgz",
+      "integrity": "sha512-y30MHEyEnS1SjMzPhioZRvZ9yz4e6FL96TFq6YcMCUSDvT8zONotAfz28kMbOUAcKCncmrCJiukjP7Q1bJT4aw==",
+      "dependencies": {
+        "rdf-stores": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-stores": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-2.1.1.tgz",
+      "integrity": "sha512-wYovM7q+12K+dV3AsPbBiAY63Dy1eoOBJ69XoL757Pqwimz2LLCrSwrjMyqc4AB+/wPgDwPeNiQA7IzD6zeAZg==",
+      "dependencies": {
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-stores/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-string-ttl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.3.2.tgz",
+      "integrity": "sha512-yqolaVoUvTaSC5aaQuMcB4BL54G/pCGsV4jQH87f0TvAx8zHZG0koh7XWrjva/IPGcVb1QTtaeEdfda5mcddJg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-string/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-terms/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdfa-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
+      "integrity": "sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser/node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/readable-from-web": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-from-web/-/readable-from-web-1.0.0.tgz",
+      "integrity": "sha512-tei03fQhxqLEklpIvocFUR9hO42hiyYvdhwoNHAjJztPAQ8QS1NqF2AhLwzGxIGidPBJ4MCqB48wn7OAFCfhsQ==",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-stream-node-to-web": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
+      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ=="
+    },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
+    "node_modules/shaclc-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.3.tgz",
+      "integrity": "sha512-MQJWVFjfzzMUvieFO0STWjIo49ywy63UkVSsr0e8+8xHUns6X+i3yWYxNKd+GtSEJjBNZxxrUubog+hnd7PvRA==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0",
+        "n3": "^1.16.3"
+      }
+    },
+    "node_modules/shaclc-write": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.5.0.tgz",
+      "integrity": "sha512-5+uFmw28BUqCW5UC4FyFwB8VTsdzPyh4LB2pAI5DRjn6xWgl1bsfied9K9HbQYrONNtmhLpPFse79N3Tvj+kLA==",
+      "dependencies": {
+        "@jeswr/prefixcc": "^1.2.1",
+        "n3": "^1.16.3",
+        "rdf-string-ttl": "^1.3.2"
+      }
+    },
+    "node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/sparqlalgebrajs/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/sparqljs": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.3.tgz",
+      "integrity": "sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==",
+      "dependencies": {
+        "rdf-data-factory": "^1.1.2"
+      },
+      "bin": {
+        "sparqljs": "bin/sparql-to-json"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/stream-to-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.1.tgz",
+      "integrity": "sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==",
+      "dependencies": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tiny-set-immediate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-set-immediate/-/tiny-set-immediate-1.0.2.tgz",
+      "integrity": "sha512-EVbaM4zXFWS4CIqVoPzY7XIioQ5LU1p49AHizwPO1KyFyp/gxy5SA8mDmfDVl/2WLQiHgUL+esO6Ig+KhpUxUw=="
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/undici": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
+    },
+    "node_modules/validate-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mu-uri-info-service",
+  "version": "0.2.1",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/redpencilio/mu-uri-info-service.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/redpencilio/mu-uri-info-service/issues"
+  },
+  "homepage": "https://github.com/redpencilio/mu-uri-info-service#readme",
+  "dependencies": {
+    "jsonld": "^9.0.0",
+    "jsonld-streaming-serializer": "^4.0.0",
+    "n3": "^1.26.0",
+    "rdf-parse": "^4.0.0",
+    "rdf-serialize": "^4.0.1",
+    "rdf-store-stream": "^3.0.0",
+    "stream-to-string": "^1.2.1"
+  }
+}


### PR DESCRIPTION
This can be used when a RDF representation is requested.

Adding this here since I believe it fits the use case (this service is typically used in a subject pages app and returning the RDF through content negotiation is common request there)